### PR TITLE
fix #1: support for multiple charts on one page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage
 
 Somewhere in your template, add this:
 
-```
+```Handlebars
 <template name="someTemplate">
 
 	{{> c3 myChartData}}
@@ -19,7 +19,7 @@ Somewhere in your template, add this:
 
 And in .js define helper that returns chart data object as described in c3 docs:
 
-```
+```JavaScript
 Template.someTemplate.helpers({
 	"myChartData": function() {
 		return {
@@ -31,13 +31,13 @@ Template.someTemplate.helpers({
 				type: 'spline'
 			}
 		};
-	}	
+	}
 });
 ```
 
 Of course, instead providing static data, you can reactively show data from collection:
 
-```
+```JavaScript
 Template.someTemplate.helpers({
 	"myChartData": function() {
 
@@ -54,11 +54,34 @@ Template.someTemplate.helpers({
 				type: 'line'
 			}
 		};
-	}	
+	}
 });
 ```
 In this example, `SomeCollection` contains key `expenses` that will be shown in the graph.
 
+JSON objects can also be given as data:
+
+```JavaScript
+// ...
+return {
+	data: {
+		json: {
+			data1: [4, 3, 5, 2],
+			data2: [6, 4, 3, 6]
+		}
+	}
+}
+```
+
+If you want to use **multiple charts on one page** you must specify a unique id, thus the syntax is a bit different:
+
+```Handlebars
+<template name="someTemplate">
+
+	{{> c3 data=myChartData id="chart4"}}
+
+</template>
+```
 
 Live example
 ============

--- a/template.html
+++ b/template.html
@@ -1,3 +1,3 @@
 <template name="c3">
-	<div id="chart"></div>
+	<div id="{{chartId}}"></div>
 </template>

--- a/template.js
+++ b/template.js
@@ -1,5 +1,16 @@
+
 Template.c3.rendered = function() {
-	var chart = c3.generate(this.data || { data: { columns: [] }});
+
+	// this.data.data.data can only exist if template has been passed a data attribute
+	// https://github.com/perak/meteor-c3/issues/1
+	var data;
+	if (this.data && this.data.data && this.data.data.data) {
+		data = this.data.data
+		data.bindto = this.data.id ? "#"+this.data.id : "#chart"
+	} else {
+		data = this.data || { data: { columns: [] }}
+	}
+	var chart = c3.generate(data);
 
 	this.autorun(function (tracker) {
 		if(UI.getData()) {
@@ -9,6 +20,9 @@ Template.c3.rendered = function() {
 };
 
 Template.c3.helpers({
+	chartId: function() {
+		return this.id || "chart"
+	}
 });
 
 Template.c3.events({


### PR DESCRIPTION
#1

This fix is backwards compatible! Meaning, the previous `{{> c3 myData}}` works along with `{{> c3 data=myData id="myChartId"}}`.
